### PR TITLE
Fix RAG logic issues: chunk size, top_k, and indexing (#11)

### DIFF
--- a/super roast bot/rag.py
+++ b/super roast bot/rag.py
@@ -13,7 +13,7 @@ DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "roast_data.txt")
 EMBEDDING_MODEL = SentenceTransformer("all-MiniLM-L6-v2")
 
 
-def load_and_chunk(file_path: str, chunk_size: int = 5) -> list[str]: 
+def load_and_chunk(file_path: str, chunk_size: int = 500) -> list[str]: 
     """
     Load a text file and split it into chunks.
 
@@ -47,7 +47,7 @@ def build_index(chunks: list[str], embedding_model):
 CHUNKS = load_and_chunk(DATA_PATH)
 INDEX = build_index(CHUNKS,EMBEDDING_MODEL)
 
-def retrieve_context(query: str, top_k: int = 0) -> str:
+def retrieve_context(query: str, top_k: int = 3) -> str:
     """
     Retrieve relevant roast context for a user query.
 
@@ -71,5 +71,5 @@ def retrieve_context(query: str, top_k: int = 0) -> str:
         np.array(query_embedding).astype("float32"), top_k
     )
 
-    results = [CHUNKS[i] for i in indices[1] if i < len(CHUNKS)]
+    results = [CHUNKS[i] for i in indices[0] if i < len(CHUNKS)]
     return "\n\n".join(results)

--- a/super roast bot/requirements.txt
+++ b/super roast bot/requirements.txt
@@ -1,5 +1,6 @@
 openai
 streamlit
-fais-cpu
+faiss-cpu
 sentence-transformers
 numpy
+python-dotenv


### PR DESCRIPTION
## Team Number : 169

## Description
Team 169
This PR fixes the RAG (Retrieval-Augmented Generation) logic in [rag.py]
 Previously, the bot was retrieving "micro-chunks" of 5 characters, searching for 0 results, and using the wrong index for FAISS results, making the roast context meaningless or empty.

## Related Issue
Closes #11

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## Changes Made
- Fixed Micro-Chunks: Increased `chunk_size` from 5 characters to 500 characters in [load_and_chunk]to ensure retrieved snippets are readable sentences.
- Fixed Empty Retrieval**: Updated the default `top_k` in [retrieve_context]from 0 to 3 so that relevant data is actually fetched from the index.
- Fixed Indexing Error: Changed result indexing from `indices[1]` to `indices[0]` to correctly access the nearest neighbor matches from FAISS.

## Testing
- [x] Verified that queries now return meaningful roast snippets from `roast_data.txt`.
- [x] Code builds and runs successfully.
- [x] No console errors or warnings.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] I have read and followed the CONTRIBUTING.md guidelines

## Additional Notes
These changes are critical for the bot to actually "know" what it's talking about when roasting the user!
screenshot of changes made:

<img width="819" height="825" alt="image" src="https://github.com/user-attachments/assets/30ffaf7e-3413-4e6d-97f7-a480e416b6d6" />

