### PR TITLE
fix: correct env variable name GROQ_API_KEY to GROQ_KEY in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ Get a free API key
 Check the `.env` file and make sure your key is configured correctly.  
 The `.env` file should look like this:
 ```
-GROQ_API_KEY=your_api_key_here
+GROQ_KEY=your_api_key_here
 ```
 
 ### Step 7: Run the App to Verify Setup


### PR DESCRIPTION
## Team Number : Team 155

## Description
Fixed environment variable naming mismatch between documentation (`CONTRIBUTING.md`) and application code (`app.py`). The documentation incorrectly referenced `GROQ_API_KEY` while the code expects `GROQ_KEY`.

## Related Issue
Closes #(issue number)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Style/UI improvement

## Changes Made
- Updated `CONTRIBUTING.md` line 181: Changed `GROQ_API_KEY=your_api_key_here` to `GROQ_KEY=your_api_key_here`
- Ensured consistency with `.env` file and `app.py` which both use `GROQ_KEY`

## Screenshots (if applicable)

**Before:**


**After:**


## Testing
- [x] Verified `.env` uses `GROQ_KEY`
- [x] Verified `app.py` reads `os.getenv("GROQ_KEY")` (line 21)
- [x] Verified `CONTRIBUTING.md` now matches both files
- [x] No console errors or warnings
- [x] Code builds successfully (`streamlit run app.py`)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

## Additional Notes
This fix resolves confusion for contributors setting up their development environment. Without this fix, users following the documentation would create a `.env` file with `GROQ_API_KEY`, but the application (`app.py`) expects `GROQ_KEY`, causing the API connection to fail silently.
