### PR TITLE
Fix: Add missing imports and _sanitize function to memory module (Iss…

### DIFF
--- a/super roast bot/memory.py
+++ b/super roast bot/memory.py
@@ -3,6 +3,10 @@ Memory Module for RoastBot - Now with SQLite Persistent Storage!
 Chat history persists across server restarts using SQLite database.
 """
 
+import re
+from collections import deque
+from database import add_chat_entry, get_chat_history, clear_chat_history
+
 MAX_MEMORY = 10
 chat_history = deque(maxlen=MAX_MEMORY)
 
@@ -67,3 +71,22 @@ def format_memory(session_id: str = "default") -> str:
     return "\n\n".join(
         [f"User: {entry['user']}\nRoastBot: {entry['bot']}" for entry in chat_history]
     )
+
+
+def _sanitize(text: str) -> str:
+    """
+    Sanitize text by removing PII (personally identifiable information).
+    
+    Args:
+        text: Text to sanitize
+    
+    Returns:
+        Sanitized text with PII replaced
+    """
+    # Remove email addresses
+    text = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '[EMAIL]', text)
+    
+    # Remove phone numbers (various formats)
+    text = re.sub(r'\b\d{3}[-.]?\d{3}[-.]?\d{4}\b', '[PHONE]', text)
+    
+    return text


### PR DESCRIPTION
## Description
Fixed the memory module that was preventing the bot from remembering previous conversation messages. The module was missing critical import statements and the _sanitize function, causing runtime errors when the bot tried to access conversation history.

## Team Number : Team 065

## Related Issue
Closes #6

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Style/UI improvement

## Changes Made
- Added missing imports: `re`, `deque`, and database functions (`add_chat_entry`, `get_chat_history`, `clear_chat_history`)
- Added missing `_sanitize()` function for PII (email and phone) removal
- Memory module now correctly persists conversation history across messages

## Screenshots (if applicable)

**Before:**
- Bot could not remember previous messages
- Memory functions failed due to missing imports
- Tests failed when trying to import `_sanitize`

**After:**
- Bot successfully remembers conversation history
- All memory functions work correctly
- All smoke tests pass ✅

## Testing
- [x] Tested memory functionality (add, get, format, clear)
- [x] Tested PII sanitization (email and phone removal)
- [x] Tested multi-turn conversation persistence
- [x] All smoke tests pass successfully
- [x] No console errors or warnings

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

## Additional Notes
**Minimal code approach**: Only added the 3 essential missing import statements and the 1 missing `_sanitize()` function (23 lines total). No other code was modified. The fix is straightforward and restores the intended functionality of the memory module.

**Testing**: Verified with both custom tests and the original smoke_test.py - all tests pass successfully.